### PR TITLE
fix logo link

### DIFF
--- a/content/manifest.json
+++ b/content/manifest.json
@@ -2,12 +2,12 @@
   "name": "Go Conference 2022 Spring",
   "short_name": "GoCon21s",
   "icons": [
-    { "src": "/images/logos/logo48.png", "sizes": "48x48", "type": "image/png" },
-    { "src": "/images/logos/logo72.png", "sizes": "72x72", "type": "image/png" },
-    { "src": "/images/logos/logo96.png", "sizes": "96x96", "type": "image/png" },
-    { "src": "/images/logos/logo144.png", "sizes": "144x144", "type": "image/png" },
-    { "src": "/images/logos/logo192.png", "sizes": "192x192", "type": "image/png" },
-    { "src": "/images/logos/logo512.png", "sizes": "512x512", "type": "image/png" }
+    { "src": "images/logos/logo48.png", "sizes": "48x48", "type": "image/png" },
+    { "src": "images/logos/logo72.png", "sizes": "72x72", "type": "image/png" },
+    { "src": "images/logos/logo96.png", "sizes": "96x96", "type": "image/png" },
+    { "src": "images/logos/logo144.png", "sizes": "144x144", "type": "image/png" },
+    { "src": "images/logos/logo192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "images/logos/logo512.png", "sizes": "512x512", "type": "image/png" }
   ],
   "start_url": "./?utm_source=web_app_manifest",
   "theme_color": "#00758D",


### PR DESCRIPTION
link of asset file of gocon.jp/2022spring/ is broken.

config at manifest.json seem to be better with relative paths

# screen shot
before
![image](https://user-images.githubusercontent.com/49754654/150352151-22c3c927-b48b-4777-9549-1c66f8bbeada.png)

after
![image](https://user-images.githubusercontent.com/49754654/150352658-88321a91-c90a-49a5-b8e9-57d068c6712d.png)

