### PR TITLE
add non-speaker sessions

### DIFF
--- a/content/sessions/_break.ja.md
+++ b/content/sessions/_break.ja.md
@@ -1,0 +1,8 @@
+---
+key: break
+title: 休憩
+id: break
+format: organize
+allroom: true
+draft: false
+---

--- a/content/sessions/_break.md
+++ b/content/sessions/_break.md
@@ -1,0 +1,8 @@
+---
+key: break
+title: Break
+id: break
+format: organize
+allroom: true
+draft: false
+---

--- a/content/sessions/_lunch.ja.md
+++ b/content/sessions/_lunch.ja.md
@@ -1,0 +1,8 @@
+---
+key: lunch
+title: ランチ休憩
+id: lunch
+format: organize
+allroom: true
+draft: false
+---

--- a/content/sessions/_lunch.md
+++ b/content/sessions/_lunch.md
@@ -1,0 +1,8 @@
+---
+key: lunch
+title: Lunch
+id: lunch
+format: organize
+allroom: true
+draft: false
+---

--- a/content/sessions/_officehour.ja.md
+++ b/content/sessions/_officehour.ja.md
@@ -4,5 +4,4 @@ title: オフィスアワー
 id: officehour
 behind: true
 draft: false
-link: https://gocon.connpass.com/event/230304/
 ---

--- a/content/sessions/_officehour.ja.md
+++ b/content/sessions/_officehour.ja.md
@@ -1,0 +1,8 @@
+---
+key: officehour
+title: オフィスアワー
+id: officehour
+behind: true
+draft: false
+link: https://gocon.connpass.com/event/230304/
+---

--- a/content/sessions/_officehour.md
+++ b/content/sessions/_officehour.md
@@ -5,5 +5,4 @@ id: officehour
 fill: true
 behind: true
 draft: false
-link: https://gocon.connpass.com/event/230304/
 ---

--- a/content/sessions/_officehour.md
+++ b/content/sessions/_officehour.md
@@ -1,0 +1,9 @@
+---
+key: officehour
+title: Office hour
+id: officehour
+fill: true
+behind: true
+draft: false
+link: https://gocon.connpass.com/event/230304/
+---

--- a/content/sessions/after-party.ja.md
+++ b/content/sessions/after-party.ja.md
@@ -5,5 +5,4 @@ id: after-party
 format: organize
 behind: true
 draft: false
-link: https://gocon.connpass.com/event/230304/
 ---

--- a/content/sessions/after-party.ja.md
+++ b/content/sessions/after-party.ja.md
@@ -1,0 +1,9 @@
+---
+key: after-party
+title: 懇親会
+id: after-party
+format: organize
+behind: true
+draft: false
+link: https://gocon.connpass.com/event/230304/
+---

--- a/content/sessions/after-party.md
+++ b/content/sessions/after-party.md
@@ -5,5 +5,4 @@ id: after-party
 format: organize
 behind: true
 draft: false
-link: https://gocon.connpass.com/event/230304/
 ---

--- a/content/sessions/after-party.md
+++ b/content/sessions/after-party.md
@@ -1,0 +1,9 @@
+---
+key: after-party
+title: After Party
+id: after-party
+format: organize
+behind: true
+draft: false
+link: https://gocon.connpass.com/event/230304/
+---

--- a/content/sessions/closing.ja.md
+++ b/content/sessions/closing.ja.md
@@ -1,0 +1,7 @@
+---
+key: closing
+title: クロージング
+id: closing
+format: organize
+draft: false
+---

--- a/content/sessions/closing.ja.md
+++ b/content/sessions/closing.ja.md
@@ -5,3 +5,4 @@ id: closing
 format: organize
 draft: false
 ---
+クロージングトークです。

--- a/content/sessions/closing.md
+++ b/content/sessions/closing.md
@@ -1,0 +1,7 @@
+---
+key: closing
+title: Closing
+id: closing
+format: organize
+draft: false
+---

--- a/content/sessions/closing.md
+++ b/content/sessions/closing.md
@@ -5,3 +5,4 @@ id: closing
 format: organize
 draft: false
 ---
+Closing talk.

--- a/content/sessions/opening.ja.md
+++ b/content/sessions/opening.ja.md
@@ -5,4 +5,4 @@ id: opening
 format: organize
 draft: false
 ---
-Opening talk.
+オープニングトークです。

--- a/content/sessions/opening.ja.md
+++ b/content/sessions/opening.ja.md
@@ -1,0 +1,8 @@
+---
+key: opening
+title: オープニング
+id: opening
+format: organize
+draft: false
+---
+Opening talk.

--- a/content/sessions/opening.md
+++ b/content/sessions/opening.md
@@ -1,0 +1,8 @@
+---
+key: opening
+title: Opening
+id: opening
+format: organize
+draft: false
+---
+Opening talk.


### PR DESCRIPTION
* 自動生成対象ではない、運営側のセッションなどの情報を追加しました
* 2021autumun から貰ってきています
  - https://github.com/GoCon/2021autumn/tree/main/content/sessions

https://github.com/GoCon/gocon-operations/issues/39 に関連する対応