### PR TITLE
changed background color of session.format-organize

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -166,7 +166,7 @@
 }
 
 .session.format-organize {
-    background-color: #b5e3ef;
+    background-color: #f8eaee;
 }
 
 .session.format-organize h4 {


### PR DESCRIPTION
* タイムテーブルの、 Break などの背景色を Go のブランドカラーから取ってきた薄いピンクにしました
  - https://go.dev/blog/go-brand

## スクショ

<img width="1043" alt="スクリーンショット 2022-02-27 17 15 54" src="https://user-images.githubusercontent.com/6882878/155874441-1895c53c-75d6-4f92-9d09-e41b85cab4c1.png">
