### PR TITLE
add sponsor names to track name

### DIFF
--- a/data/rooms.yml
+++ b/data/rooms.yml
@@ -1,12 +1,12 @@
 - key: track-a
   label: Track A
-  description: Remo - Track A
+  sponsor: 店舗スタッフDXサービス「STAFF START」
   url: ""
 - key: track-b
   label: Track B
-  description: Remo - Track B
+  sponsor: ビットキー
   url: ""
 - key: remo
   label: Remo
-  description: Remo
+  sponsor: ""
   url: ""

--- a/layouts/schedule/list.html
+++ b/layouts/schedule/list.html
@@ -74,12 +74,14 @@
 		<!-- Room {{ $room.room }} -->
 		<div class="room {{ if not (modBool $index 2)}}odd{{end}}" style="--room: {{ $index }};">
 			<h3>
-				<a href="{{ .url }}">
-				{{ .label }}
-				{{ if .description }}
-				<small>{{ .description }}</small>
+				<div>
+					{{ .label }}
+				</div>
+				{{ if .sponsor }}
+					<div>
+						<small><b>sponsored by {{ .sponsor }}</b></small>
+					</div>
 				{{ end }}
-				</a>
 			</h3>
 		</div>
 

--- a/raw_data/rooms.csv
+++ b/raw_data/rooms.csv
@@ -1,4 +1,4 @@
-key,label,order,description,url
-track-a,Track A,1,Remo - Track A,
-track-b,Track B,2,Remo - Track B,
-remo,Remo,3,Remo,
+key,label,order,sponsor,url
+track-a,Track A,1,店舗スタッフDXサービス「STAFF START」,
+track-b,Track B,2,ビットキー,
+remo,Remo,3,,

--- a/scripts/rooms/main.go
+++ b/scripts/rooms/main.go
@@ -12,10 +12,10 @@ import (
 )
 
 type Room struct {
-	Key         string `csv:"key"`
-	Label       string `csv:"label"`
-	Description string `csv:"description"`
-	URL         string `csv:"url"`
+	Key     string `csv:"key"`
+	Label   string `csv:"label"`
+	Sponsor string `csv:"sponsor"`
+	URL     string `csv:"url"`
 }
 
 const fileName = "rooms"

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -212,7 +212,7 @@ section.schedule .room {
 }
 
 .section.schedule .room h3 {
-    height: 4.5em
+    height: 4.5em;
 }
 
 .section.schedule main>section.schedule .day {

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -207,6 +207,18 @@
     background-color: transparent;
 }
 
+section.schedule .room {
+    text-align: center;
+}
+
+.section.schedule .room h3 {
+    height: 4.5em
+}
+
+.section.schedule main>section.schedule .day {
+    grid-template-rows: 6em repeat(calc(var(--end) - 1),var(--base-grid-height,6em));
+}
+
 @media (max-width: 59.99em) {
     .section.schedule main>section.schedule .day .slot {
         display: none !important;


### PR DESCRIPTION
* https://github.com/GoCon/gocon-operations/issues/135 の対応
* プラチナGoルドスポンサー企業様に対応する名前をトラック名に追加します

## スクショ

![スクリーンショット 2022-03-08 21 22 51](https://user-images.githubusercontent.com/6882878/157238736-8d7d549c-8d21-4e45-92bd-70e84c47c347.png)
![スクリーンショット 2022-03-08 21 23 03](https://user-images.githubusercontent.com/6882878/157238742-e4902e78-504d-4d96-b7b8-43502398cf08.png)
![スクリーンショット 2022-03-08 21 23 13](https://user-images.githubusercontent.com/6882878/157238743-98522aad-4611-4ba9-8cc5-8447f9374230.png)
![スクリーンショット 2022-03-08 21 23 22](https://user-images.githubusercontent.com/6882878/157238748-669e2cf0-6676-4740-a22a-a7deb284083a.png)
