### PR TITLE
fixed to show challenge sessions in sessions list page

### DIFF
--- a/layouts/sessions/list.html
+++ b/layouts/sessions/list.html
@@ -5,7 +5,7 @@
 <section>
 	<ul class="talks">
 		{{ $sessions := where .Site.AllPages ".Section" "sessions" }}
-		{{ $types := (slice "short_session" "long_session" "lt_session") }}
+		{{ $types := (slice "short_session" "long_session" "lt_session" "challenge_session") }}
 		{{ range sort $sessions ".Title" }}
 			{{ if intersect (slice .Params.talkType) $types }}
 		<li class="talk tag-{{ anchorize (delimit (.Params.tags | default (slice)) "" ) }}">{{ partial "session.html" . }}</li>


### PR DESCRIPTION
* Challenge Session が Sessions に表示されていなかったのを修正しました

Close: https://github.com/GoCon/gocon-operations/issues/156