### PR TITLE
fix tags rendering in schedule

### DIFF
--- a/layouts/partials/schedule-session.html
+++ b/layouts/partials/schedule-session.html
@@ -45,9 +45,7 @@
     {{ if .Params.tags }}
     <div class="tags">
       {{ range .Params.tags }}
-        {{ range first 1 (where $.Site.Data.categories "key" .) }}
-        <span>{{ .name }}</span>
-        {{ end }}
+        <span>{{ . }}</span>
       {{ end }}
     </div>
     {{ end }}
@@ -80,9 +78,7 @@
     <div class="session-info">
       <div class="tags">
         {{ range .Params.tags }}
-          {{ range first 1 (where $.Site.Data.categories "key" .) }}
-          <span>{{ .name }}</span>
-          {{ end }}
+          <span>{{ . }}</span>
         {{ end }}
       </div>
   </div>


### PR DESCRIPTION
* タグのレンダリングがタイムテーブル上でおかしかったので修正する
* タグを別のデータと紐付けていた箇所があったが、個別のセッションページではこの紐付けを行っていなかったのでここについても外した
* Close: https://github.com/GoCon/gocon-operations/issues/164

## スクショ

### Before

<img width="927" alt="スクリーンショット 2022-03-24 22 52 08" src="https://user-images.githubusercontent.com/6882878/159931329-72f91aac-ec9c-4b34-b3b8-38ae0d152f5a.png">

### After

<img width="960" alt="スクリーンショット 2022-03-24 22 52 21" src="https://user-images.githubusercontent.com/6882878/159931381-be3763e7-fd1c-4501-9c88-2d6857d44789.png">
