### PR TITLE
make header transparent

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1,3 +1,13 @@
+body {
+    margin: 0;
+}
+
+body header {
+    color: #000;
+    background-color: transparent;
+    box-shadow: none;
+}
+
 .jumbo .inner-wrapper .inner {
     color: #000;
 }


### PR DESCRIPTION
* ヘッダ背景を透明するのを先にやっておいた方が色々確認しやすそうだったので変えました
* ヘッダの分のマージンがページ上部に付いていたので剥がしました

## スクショ

![スクリーンショット 2022-04-02 14 19 31](https://user-images.githubusercontent.com/6882878/161367733-4c8c1ab6-4f04-4494-987e-0cdb9a69d957.png)
![スクリーンショット 2022-04-02 14 19 39](https://user-images.githubusercontent.com/6882878/161367737-38a4de3f-4406-4352-bae9-d094fa5eccd1.png)
