### PR TITLE
fix header logo style

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,7 +1,7 @@
 <header id="header">
 	<div class="top-content">
 
-		<div class="logo-text">
+		<div class="logo-text-container">
 			<a href="{{"/" | relLangURL}}">
 				<div class="logo-text" id="logo-text" alt="logo {{ .Site.Title }}"></div>
 				<div class="logo-text--white logo--disable"  id="logo-text--white" alt="logo {{ .Site.Title }}"></div>


### PR DESCRIPTION
* `.logo-text` の class が親のdivにも効いて、2重にロゴが出ていた
* 白いロゴの背景に黒いロゴが出ていて、ちょっと縁取りみたいになっていた
* (もうちょいPNGの解像度上げてあげてもいいかもと言う感じもちょっとある)

## スクショ

### Before

![スクリーンショット 2022-04-07 22 58 42](https://user-images.githubusercontent.com/6882878/162216866-b9983b8f-22a9-4c5f-8c69-2f43c1e38ac2.png)

### After

![スクリーンショット 2022-04-07 22 56 14](https://user-images.githubusercontent.com/6882878/162216901-fa054286-f5dc-45fd-bf0b-98593a04411f.png)
