### PR TITLE
update partner section header style

### DIFF
--- a/assets/scss/index.scss
+++ b/assets/scss/index.scss
@@ -5,3 +5,4 @@
 @import "staffs/list.scss";
 @import "home/main-visual.scss";
 @import "sakura.scss";
+@import "partners.scss"

--- a/assets/scss/partners.scss
+++ b/assets/scss/partners.scss
@@ -1,0 +1,61 @@
+.partners {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+
+  .partners-group {
+    padding-top: 36px;
+    max-width: 1140px;
+    width: 100%;
+
+    .fancy-custom {
+      height: 24px;
+      text-align: center;
+      color: var(--base-secondary-text);
+      position: relative;
+
+      &:before {
+        content: "";
+        position: absolute;
+        height: 6px;
+        width: 100%;
+        left: 0;
+        top: calc(50% - 3px);
+        z-index: 1;
+      }
+
+      .partner-category {
+        position: absolute;
+        display: flex;
+        width: 100%;
+        justify-content: center;
+        z-index: 2;
+        .category-name {
+          font-size: 24px;
+          line-height: 24px;
+          font-weight: 600;
+          background-color: white;
+          padding: 0px 40px;
+        }
+      }
+    }
+  }
+
+  .partner-platinum {
+    .fancy-custom:before { background-color: var(--bg-yellow); }
+    .partner-category { color: var(--text-yellow); }
+  }
+  .partner-gold {
+    .fancy-custom:before { background-color: var(--bg-pink); }
+    .partner-category { color: var(--text-pink); }
+  }
+  .partner-silver {
+    .fancy-custom:before { background-color: var(--bg-blue); }
+    .partner-category { color: var(--text-blue); }
+  }
+  .partner-bronze {
+    .fancy-custom:before { background-color: var(--bg-brown); }
+    .partner-category { color: var(--text-brown); }
+  }
+}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -48,7 +48,7 @@
 
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-	<link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500&display=swap" rel="stylesheet">
+	<link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&display=swap" rel="stylesheet">
 	<link rel="stylesheet" href="/theme.css" media="all">
 	<link rel="stylesheet" href="/css/custom.css" media="all">
 

--- a/layouts/shortcodes/partners.html
+++ b/layouts/shortcodes/partners.html
@@ -7,8 +7,12 @@
 {{ $site := .Site }}
 {{ range (split (.Get "categories") ",") }}
 <section class="partners-group partner-{{ . }}">
-<h3 class="fancy">
-<span>{{- i18n (print "partner_category_" .) -}}</span>
+<h3 class="fancy-custom">
+<div class="partner-category">
+	<div class="category-name">
+		{{- i18n (print "partner_category_" .) -}}
+	</div>
+</div>
 </h3>
 <ul>
 	{{ $partners := where $site.AllPages "Params.category" . }}


### PR DESCRIPTION
Close #43 

* スポンサーのヘッダのスタイルを変える
* スマホの時に画面幅が合わなくなる問題がセットで解消しました

## スクショ

### デスクトップ

<img width="1441" alt="スクリーンショット 2022-04-13 22 26 02" src="https://user-images.githubusercontent.com/6882878/163191164-571b7712-aec2-437b-9acc-e9c6c732e1f3.png">
<img width="1443" alt="スクリーンショット 2022-04-13 22 26 10" src="https://user-images.githubusercontent.com/6882878/163191173-c0a038c9-f25d-410b-862d-14009848f78c.png">

### スマホ

もうちょい調整してもいい気がするけど一旦許容範囲内かなと思います！

<img width="309" alt="スクリーンショット 2022-04-13 22 26 22" src="https://user-images.githubusercontent.com/6882878/163191187-a5993ecc-5087-4d31-8602-79b09c46d8a1.png">
<img width="308" alt="スクリーンショット 2022-04-13 22 26 36" src="https://user-images.githubusercontent.com/6882878/163191188-089b0d5e-0a2d-4e18-a686-380ebe2c2565.png">

## デザイン

<img width="683" alt="スクリーンショット 2022-04-13 22 31 02" src="https://user-images.githubusercontent.com/6882878/163191712-4156e597-b7de-402b-a9c9-4e059556a688.png">
