### PR TITLE
fix twitter share url

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -40,6 +40,9 @@ other = "Come join us at Go Conference 2022 Spring!! #gocon"
 [twitter_share_label]
 other = "Share on Twitter"
 
+[twitter_share_url]
+other = "https://gocon.jp/2022spring/"
+
 [footer_follow_blog]
 other = "Follow our"
 

--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -43,6 +43,9 @@ other = "Go Conference 2022 Springに参加しましょう！ #gocon"
 [twitter_share_label]
 other = "Twitterでシェアする"
 
+[twitter_share_url]
+other = "https://gocon.jp/2022spring/ja/"
+
 [footer_follow_blog]
 other = " "
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -5,11 +5,9 @@
 			<div class="share">
 				<header>{{ i18n "footer_share" }}</header>
 				<ul class="social-list">
-					{{ range .Site.Data.footer.share }}
 					<li>
-						{{ $url := .URL | relLangURL }}
-						{{ partial "social-sharer.html" (dict "context" . "url" $url "name" .name) }}
-						{{ end }}
+						{{ partial "social-sharer.html" (dict "context" . "url" (i18n "twitter_share_url") "name" "twitter") }}
+					</li>
 				</ul>
 			</div>
 			<div class="follow">


### PR DESCRIPTION
* Twitterのshare urlが空だったので直しました
* 言語切替時のURL切り替え処理が面倒だったのでi18nにまとめちゃいました

## Before

<img width="616" alt="スクリーンショット 2022-04-15 14 40 59" src="https://user-images.githubusercontent.com/6882878/163526366-02499751-39f6-4286-a694-7f79c11f75ec.png">

## After

<img width="624" alt="スクリーンショット 2022-04-15 14 42 19" src="https://user-images.githubusercontent.com/6882878/163526484-c2e081ec-dc37-4a9f-ad2c-8200f7e07e16.png">

