### PR TITLE
change Remo page name to Floor Guide

### DIFF
--- a/assets/scss/navigation.scss
+++ b/assets/scss/navigation.scss
@@ -110,7 +110,7 @@
           a {
             font-size: 20px;
             line-height: 20px;
-            padding: 9px 16px;
+            padding: 9px 12px;
           }
         }
       }

--- a/content/remo/_index.ja.md
+++ b/content/remo/_index.ja.md
@@ -1,5 +1,5 @@
 ---
-title: Remo
+title: Floor Guide
 menu:
   main:
     weight: 100

--- a/content/remo/_index.md
+++ b/content/remo/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Remo
+title: Floor Guide
 menu:
   main:
     weight: 100


### PR DESCRIPTION
https://github.com/GoCon/gocon-operations/issues/43 の対応の一つ

* "Remo" ページの名前を "Floor Guide" にしたいと言う話だったので変える
* メニューの余白が足りなくなったので、心苦しいですがちょっと詰めます 🙏 
  - メディアクエリでもうちょい段階付けて調整でもいいかもですが、ややこしくなりそうなので…

## スクショ

![スクリーンショット 2022-04-21 21 39 50](https://user-images.githubusercontent.com/6882878/164459870-4e98737d-2fce-4874-81c7-7348c2dee7d0.png)

