### PR TITLE
fix session page duplication

### DIFF
--- a/layouts/sessions/list.html
+++ b/layouts/sessions/list.html
@@ -2,7 +2,7 @@
 
 {{ .Content }}
 
-{{ $sessions := where .Site.AllPages ".Section" "sessions" }}
+{{ $sessions := .RegularPages }}
 {{ $sessions = sort $sessions ".Title" }}
 
 <section>


### PR DESCRIPTION
日本語のsessionsページのリストで重複表示されてしまっていたので直します