### PR TITLE
fix partner logo in schedule page

### DIFF
--- a/layouts/partials/schedule-session.html
+++ b/layouts/partials/schedule-session.html
@@ -53,7 +53,8 @@
   {{end}}
 </a>
 {{else}}
-{{$partner := index (where (where .Site.Pages "Params.category" "in" "platinum,gold,silver,bronze,free") ".Params.key" .Params.partner) 0}}
+
+{{$partner := index (where (where .Site.AllPages "Params.category" "in" "platinum,gold,silver,bronze,free") ".Params.key" .Params.partner) 0}}
 
 <a href="{{ .Permalink }}">
   <h4 title="{{ .Title }}">

--- a/layouts/partials/schedule-session.html
+++ b/layouts/partials/schedule-session.html
@@ -53,7 +53,6 @@
   {{end}}
 </a>
 {{else}}
-
 {{$partner := index (where (where .Site.AllPages "Params.category" "in" "platinum,gold,silver,bronze,free") ".Params.key" .Params.partner) 0}}
 
 <a href="{{ .Permalink }}">


### PR DESCRIPTION
日本語版タイムテーブルでロゴ表示に問題があったので修正します

![スクリーンショット 2022-04-22 21 27 01](https://user-images.githubusercontent.com/6882878/164714215-79c2c57c-a347-4626-a585-79349ec2a3a2.png)
![スクリーンショット 2022-04-22 21 26 57](https://user-images.githubusercontent.com/6882878/164714203-96ecd047-2e38-4c94-8de5-69f8ccd6f3f3.png)
